### PR TITLE
fix: prevent concurrent fetches of provider metadata

### DIFF
--- a/testutil_test.go
+++ b/testutil_test.go
@@ -12,13 +12,14 @@ var (
 )
 
 func CheckCache(cfguri string) bool {
-	v, ok := cacheProviderMeta.Load(cfguri)
+	muxPM.RLock()
+	defer muxPM.RUnlock()
+
+	cfg, ok := cacheProviderMeta[cfguri]
 	if !ok {
 		log.Printf("cacheProviderMeta: %s not found in cache", cfguri)
 		return false
 	}
-
-	cfg := v.(ProviderMetadata) //nolint:forcetypeassert
 
 	return jwkCache.IsRegistered(cfg.JWKSURI)
 }


### PR DESCRIPTION
The `fetchProviderMetadata` function performs an HTTP request to retrieve provider metadata. When multiple concurrent requests for the same metadata URI occur, this can lead to unnecessary HTTP requests and increased latency.

This commit addresses this issue by introducing a mutex to protect the metadata fetching process:

- A `sync.RWMutex` is used to guard access to the `cacheProviderMeta` map.
- Before fetching metadata, a read lock is acquired. If the metadata is not in the cache, a write lock is acquired, the metadata is fetched and stored in the cache, and the write lock is released.
- This ensures that only one HTTP request is made for a given metadata URI at a time, even under heavy concurrency.

This change reduces unnecessary HTTP requests, improves performance, and reduces the load on the provider metadata server.